### PR TITLE
README updates and create-service-account.sh fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ How to build the container:
 
 The create_service_account.sh script takes two parameters: 
 
-    Service Account Name - the name of the service account you want to create
-    Namespace Path - the path to launch this service under marathon management.  e.g. / or /dev
+Service Account Name - the name of the service account you want to create
+Namespace Path - the path to launch this service under marathon management.  e.g. / or /dev
 
-####    create-service-account.sh <service-account-name> <namespace-path>
+####    $ ./create-service-account.sh [service-account-name] [namespace-path]
 
 ## Program Execution
 The python program runs on marathon and can be executed using the following command:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ How to build the container:
     docker tag <tag-id> <docker-hub-name>:marathon-autoscale:latest
     docker push <docker-hub-name>:marathon-autoscale:latest
 
+## Creating a service account
+
+The create_service_account.sh script takes two parameters: 
+
+    Service Account Name - the name of the service account you want to create
+    Namespace Path - the path to launch this service under marathon management.  e.g. / or /dev
+
+####    create-service-account.sh <service-account-name> <namespace-path>
+
 ## Program Execution
 The python program runs on marathon and can be executed using the following command:
 
@@ -39,6 +48,11 @@ Input paramters user will be prompted for:
     AS_COOL_DOWN_FACTOR # how many times should we poll before scaling down
     AS_TRIGGER_NUMBER # how many times should we pole before scaling up
     AS_INTERVAL #how often should we poll in seconds
+
+**Notes** 
+
+For MIN_CPU_TIME and MAX_CPU_TIME on multicore containers, the calculation for determining the value is # of CPU * desired CPU utilization percentage = CPU time (e.g. 80 cpu time * 2 cpu = 160 cpu time)
+For MIN_MEM_PERCENT and MAX_MEM_PERCENT on very small containers, remember that Mesos adds 32MB to the container spec for container overhead (namespace and cgroup), so your target percentages should take that into account.  Alternatively, consider using the CPU only scaling mode for containers with very small memory footprints.
 
 If you are using an authentication:
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ How to build the container:
 
 The create_service_account.sh script takes two parameters: 
 
-Service Account Name - the name of the service account you want to create
-Namespace Path - the path to launch this service under marathon management.  e.g. / or /dev
+    Service-Account-Name #the name of the service account you want to create
+    Namespace-Path #the path to launch this service under marathon management.  e.g. / or /dev
 
 ####    $ ./create-service-account.sh [service-account-name] [namespace-path]
 
@@ -30,6 +30,7 @@ The python program runs on marathon and can be executed using the following comm
 #### $ dcos marathon app add marathon.json
 
 Where the marathon.json has been built from one of the samples:
+
     sample-autoscale-noauth-marathon.json #security disabled or OSS DC/OS
     sample-autoscale-username-marathon.json #security permissive or strict on Enterprise DC/OS, using username and password (password stored as a secret)
     sample-autoscale-svcacct-marathon.json #security permissive or strict on Enterprise DC/OS, using service account and private key (private key stored as a secret)

--- a/create-service-account.sh
+++ b/create-service-account.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-if [ -z ${1+x} ]; then echo "Principal name is unset"; else echo "Principal is set to '$1'"; fi
-if [ -z ${2+x} ]; then echo "Namespace is unset"; else echo "Namespace is set to '$2'"; fi
+if [ -z ${1+x} ]; then echo "Principal name is unset"; exit 1; else echo "Principal is set to '$1'"; fi
+if [ -z ${2+x} ]; then echo "Namespace is unset"; exit 1; else echo "Namespace is set to '$2'"; fi
 
 SERVICE_PRINCIPAL=$1
 NAMESPACE="${2/\//%252F}"

--- a/create-service-account.sh
+++ b/create-service-account.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -ex
 
+if [ -z ${1+x} ]; then echo "Principal name is unset"; else echo "Principal is set to '$1'"; fi
+if [ -z ${2+x} ]; then echo "Namespace is unset"; else echo "Namespace is set to '$2'"; fi
+
 SERVICE_PRINCIPAL=$1
 NAMESPACE="${2/\//%252F}"
 echo $NAMESPACE
@@ -34,18 +37,37 @@ curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show cor
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:adminrouter:ops:slave/users/$SERVICE_PRINCIPAL/full
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:adminrouter:service:marathon/users/$SERVICE_PRINCIPAL/full
 
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:endpoint:path:%252Fcontainers -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:endpoint:path:%252Fcontainers/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:endpoint:path:%252Fmetrics%252Fsnapshot -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:endpoint:path:%252Fmetrics%252Fsnapshot/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:endpoint:path:%252Fmonitor%252Fstatistics -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:endpoint:path:%252Fmonitor%252Fstatistics/users/$SERVICE_PRINCIPAL/read
 
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:log -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:log/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:service:marathon:marathon:admin:events -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:service:marathon:marathon:admin:events/users/$SERVICE_PRINCIPAL/read
 
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:executor:app_id:$NAMESPACE -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:executor:app_id:$NAMESPACE/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:sandbox:app_id:$NAMESPACE -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:sandbox:app_id:$NAMESPACE/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:task:app_id:$NAMESPACE -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:agent:task:app_id:$NAMESPACE/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:executor:app_id:$NAMESPACE -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:mesos:master:executor:app_id:$NAMESPACE/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:service:marathon:marathon:services:$NAMESPACE -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:service:marathon:marathon:services:$NAMESPACE/users/$SERVICE_PRINCIPAL/read
+
+curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" -H 'Content-Type: application/json' $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:service:marathon:marathon:services:$NAMESPACE -d '{"description":""}'
 curl -X PUT --cacert dcos-ca.crt -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:service:marathon:marathon:services:$NAMESPACE/users/$SERVICE_PRINCIPAL/update
 
 


### PR DESCRIPTION
README updated with notes from previous PR and
create-service-account.sh now creates the non-standard permissions
required to run the autoscaler rather than just granting them. Should
now work on both permissive and strict mode clusters.