### PR TITLE
fix bug for 'and' & 'or' mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version ?= 0.5.0
+version ?= 0.5.1
 image_name ?= mesosphere/marathon-autoscaler
 full_image_name ?= $(image_name):v$(version)
 

--- a/autoscaler/modes/scalebycpuormem.py
+++ b/autoscaler/modes/scalebycpuormem.py
@@ -22,8 +22,9 @@ class ScaleByCPUOrMemory(AbstractMode):
         # Instantiate the CPU/Memory mode classes
         for idx, mode in enumerate(list(self.mode_map.keys())):
             self.mode_map[mode] = self.mode_map[mode](
-                api_client,
-                app,
+                api_client=self.api_client,
+                app=self.app,
+                agent_stats=self.agent_stats,
                 dimension={
                     'min': dimension['min'][idx],
                     'max': dimension['max'][idx]

--- a/autoscaler/modes/scalecpuandmem.py
+++ b/autoscaler/modes/scalecpuandmem.py
@@ -20,8 +20,9 @@ class ScaleByCPUAndMemory(AbstractMode):
         # Instantiate the CPU/Memory mode classes
         for idx, mode in enumerate(list(self.mode_map.keys())):
             self.mode_map[mode] = self.mode_map[mode](
-                api_client,
-                app,
+                api_client=self.api_client,
+                app=self.app,
+                agent_stats=self.agent_stats,
                 dimension={
                     'min': dimension['min'][idx],
                     'max': dimension['max'][idx]


### PR DESCRIPTION
I found some bug at `marathon-autoscaler 0.5.0 version`
The bug is distrub the autoscaler from operating normally in `and` and `or` modes.

Check the [link ](http://git.kb-sys.co.kr/GeunSam2/marathon-autoscale-bugfix-200116)here for details.

This PR will help to fix bug issue #32 